### PR TITLE
Fix authentication for user/group validations - passwords fail to be checked

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -1708,11 +1708,6 @@ ngx_http_auth_ldap_authenticate(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t 
                     }
                 }
 
-                if (ctx->server->require_valid_user == 0) {
-                    ctx->phase = PHASE_NEXT;
-                    break;
-                }
-
                 /* Initiate bind using the found DN and request password */
                 rc = ngx_http_auth_ldap_check_bind(r, ctx);
                 if (rc == NGX_AGAIN) {


### PR DESCRIPTION
This fixes issue #40.  User passwords should _always_ be checked during authentication (except when a user fails to satisfy given requirements).  Previously, the PHASE_CHECK_BIND step of authentication would not check passwords in any LDAP configuration where `require valid_user` was not specified (eg using `require user` or `require group`).
