### PR TITLE
Brought nyoxi's up to HEAD, and fixed a type issue

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -1213,7 +1213,7 @@ ngx_http_auth_ldap_ssl_handshake(ngx_http_auth_ldap_connection_t *c)
         return;
     }
 
-    ngx_http_auth_ldap_ssl_handshake_handler(c);
+    ngx_http_auth_ldap_ssl_handshake_handler(c->conn.connection);
     return;
 }
 #endif


### PR DESCRIPTION
nyoxi's previous commits looked like they would fix the issue with nginx minions crashing when the session with the ldap server broke (#34) and the issues with building without OpenSSL linked (#22) but it wasn't compiling on my system. However when I attempted to compile them into nginx 1.7.1 was resulting in a type error. This seems to fix that problem?

I am not an expert in C, so if I did something horribly wrong I apologize. 
