### PR TITLE
Authentication timeout and segmentation fault fix on multiple, concurrent requests being processed at the same time

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -1967,16 +1967,6 @@ ngx_http_auth_ldap_check_bind(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *c
         ctx->c->state = STATE_BINDING;
         ctx->iteration++;
         
-	// added by prune - 20140227
-	// we have to rebind THIS SAME connection as admin user or the next search could be
-	// made as non privileged user
-	// see https://github.com/kvspb/nginx-auth-ldap/issues/36
-	// this is quick and dirty patch
-        int rebind_msgid;
-        cred.bv_val = (char *) ctx->server->bind_dn_passwd.data;
-        cred.bv_len = ctx->server->bind_dn_passwd.len;
-        rc = ldap_sasl_bind(ctx->c->ld,(const char *) ctx->server->bind_dn.data, LDAP_SASL_SIMPLE, &cred, NULL, NULL, &rebind_msgid);
-        
         return NGX_AGAIN;
     }
 

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -1014,6 +1014,12 @@ ngx_http_auth_ldap_get_connection(ngx_http_auth_ldap_ctx_t *ctx)
     ngx_queue_t *q;
     ngx_http_auth_ldap_connection_t *c;
 
+    /*
+     * If we already have a connection, just say we got them one.
+     */
+    if (ctx->c != NULL)
+        return 1;
+
     server = ctx->server;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->r->connection->log, 0, "http_auth_ldap: Wants a free connection to \"%V\"",
@@ -1075,8 +1081,6 @@ ngx_http_auth_ldap_reply_connection(ngx_http_auth_ldap_connection_t *c, int erro
         ctx->error_msg.len = 0;
         ctx->error_msg.data = NULL;
     }
-
-    ngx_http_auth_ldap_return_connection(c);
 
     ngx_http_auth_ldap_wake_request(ctx->r);
 }


### PR DESCRIPTION
We had the problem that whenever we ran multiple, concurrent requests nginx would report that for some requests the LDAP Authentication timed out and they would take at least 10 seconds to complete.

We found a couple of little problems with the async code that have been fixed here. We've been testing it for the last couple of weeks and it all seems to be working perfectly!

One problem was that sometimes it was assumed a LDAP request was sent already when it wasn't (because it couldn't get a LDAP connection). 

Another problem was that in order for all of this to work, all the LDAP commands one request needs should be done on one LDAP connection one after the after - they are dependent on each other. But instead of trying to enforce that, it kept switching up between requests. This tries to make the LDAP connection more sticky to the request till it is done - but it is not enforcing it. It works well enough in practice, though.

This should fix #8, #36 and #56.

Thanks so much!
Patrik