### PR TITLE
Treating LDAP_NO_SUCH_OBJECT as soft error, updating example.conf

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -38,20 +38,21 @@ http {
 }
 
 server {
-	listen       8081;
-	server_name  localhost;
+  listen       8081;
+  server_name  localhost;
 
-	location / {
-      # adding ldap authentication
-	    auth_ldap "Closed content";
-      auth_ldap_servers ad_1;
+  location / {
+    # adding ldap authentication
+    auth_ldap "Closed content";
+    auth_ldap_servers ad_1;
 
-	    root   html;
-	    index  index.html index.htm;
+    root html;
+    index index.html index.htm;
 	}
 
-	error_page   500 502 503 504  /50x.html;
-	location = /50x.html {
-	    root   html;
-	}
+  error_page   500 502 503 504  /50x.html;
+
+  location = /50x.html {
+    root html;
+  }
 }

--- a/example.conf
+++ b/example.conf
@@ -18,7 +18,7 @@ http {
       # bind as
       binddn "CN=Operator,OU=Service Accounts,DC=company,DC=com";
       # bind pw
-      binddn_passwd <PUT Operator PASSWORD HERE>;
+      binddn_passwd <PUT Operator's PASSWORD HERE>;
       # group attribute name which contains member object
       group_attribute member;
       # search for full DN in member object

--- a/example.conf
+++ b/example.conf
@@ -48,7 +48,7 @@ server {
 
     root html;
     index index.html index.htm;
-	}
+  }
 
   error_page   500 502 503 504  /50x.html;
 

--- a/example.conf
+++ b/example.conf
@@ -11,25 +11,41 @@ http {
     sendfile        on;
     keepalive_timeout  65;
 
-    auth_ldap_url ldap://ldap.example.com/dc=example,dc=com?uid?sub?(objectClass=person);
-    auth_ldap_binddn cn=nginx,ou=service,dc=example,dc=com;
-    auth_ldap_binddn_passwd mYsUperPas55W0Rd;
+    # define ldap server
+    ldap_server ad_1 {
+      # user search base.
+      url "ldap://<YOUR LDAP SERVER>:3268/OU=Offices,DC=company,DC=com?sAMAccountName?sub?(objectClass=person)";
+      # bind as
+      binddn "CN=Operator,OU=Service Accounts,DC=company,DC=com";
+      # bind pw
+      binddn_passwd <PUT Operator PASSWORD HERE>;
+      # group attribute name which contains member object
+      group_attribute member;
+      # search for full DN in member object
+      group_attribute_is_dn on;
+      # matching algorithm (any / all)
+      satisfy any;
+      # list of allowed groups
+      require group "CN=Admins,OU=My Security Groups,DC=company,DC=com";
+      require group "CN=New York Users,OU=My Security Groups,DC=company,DC=com";
+      # list of allowed users
+      # require 'valid_user' cannot be used together with 'user' as valid user is a superset
+      # require valid_user;
+      require user "CN=Batman,OU=Users,OU=New York Office,OU=Offices,DC=company,DC=com";
+      require user "CN=Robocop,OU=Users,OU=New York Office,OU=Offices,DC=company,DC=com";
+    }
 
-    auth_ldap_group_attribute uniquemember; # default 'member'
-    auth_ldap_group_attribute_is_dn on; # default on
+}
 
-    server {
+server {
 	listen       8081;
 	server_name  localhost;
 
 	location / {
+      # adding ldap authentication
 	    auth_ldap "Closed content";
-	    
-	    #auth_ldap_require valid_user;
-	    auth_ldap_require user 'cn=Super User,ou=user,dc=example,dc=com';
-	    auth_ldap_require group 'cn=admins,ou=group,dc=example,dc=com';
-	    auth_ldap_require group 'cn=user,ou=group,dc=example,dc=com';
-	    auth_ldap_satisfy any;
+      auth_ldap_servers ad_1;
+
 	    root   html;
 	    index  index.html index.htm;
 	}
@@ -38,5 +54,4 @@ http {
 	location = /50x.html {
 	    root   html;
 	}
-    }
 }

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -1871,7 +1871,7 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
                 ctx->outcome = OUTCOME_ALLOW;
                 return NGX_OK;
             }
-        } else if (ctx->error_code == LDAP_COMPARE_FALSE || ctx->error_code == LDAP_NO_SUCH_ATTRIBUTE) {
+        } else if (ctx->error_code == LDAP_COMPARE_FALSE || ctx->error_code == LDAP_NO_SUCH_ATTRIBUTE || ctx->error_code == LDAP_NO_SUCH_OBJECT) {
             if (ctx->server->satisfy_all == 1) {
                 ctx->outcome = OUTCOME_DENY;
                 return NGX_DECLINED;


### PR DESCRIPTION
Problem: When administrator specifies a non existing group or user, module fails authentication request at that very moment and skips additional group or user checking. Such behavior contradicts "satisfy any" logic and can cause authentication problems that can be hard to diagnose.

Solution: Handle LDAP_NO_SUCH_OBJECT exception the same way as LDAP_COMPARE_FALSE or LDAP_NO_SUCH_OBJECT.

+ example.conf update