### PR TITLE
Compile cleanly on FreeBSD

### DIFF
--- a/config
+++ b/config
@@ -5,7 +5,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_auth_ldap_module.c"
 CORE_LIBS="$CORE_LIBS -lldap"
 
 case "$NGX_PLATFORM" in
-    Linux:*|SunOS:*)
+    FreeBSD:*|Linux:*|SunOS:*)
         CORE_LIBS="$CORE_LIBS -llber"
     ;;
 esac


### PR DESCRIPTION
Compile cleanly on FreeBSD

FreeBSD 10.1 (tested version) needs the lber during linking.