### PR TITLE
Update ngx_http_auth_ldap_module.c - Initialize variable before use.

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -803,6 +803,7 @@ ngx_http_auth_ldap_init_cache(ngx_cycle_t *cycle)
     }
 
     want = (conf->cache_size + 7) / 8;
+    count = 0;
     for (i = 0; i < sizeof(primes)/sizeof(primes[0]); i++) {
         count = primes[i];
         if (count >= want) {


### PR DESCRIPTION
Initialize count on line 806. Prevents compilation errors.

```
nginx-auth-ldap/ngx_http_auth_ldap_module.c:815:26: error: variable 'count' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
    cache->num_buckets = count;
                         ^~~~~
nginx-auth-ldap/ngx_http_auth_ldap_module.c:793:27: note: initialize the variable 'count' to silence this warning
    ngx_uint_t want, count, i;
                          ^
                           = 0
```