### PR TITLE
remove timedout request ctx's from waiting_requests queue

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -1800,6 +1800,12 @@ ngx_http_auth_ldap_authenticate(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t 
         if (ctx->c != NULL) {
             ngx_http_auth_ldap_return_connection(ctx->c);
         }
+
+        // Remove ctx from waiting_requests queue if it was added.
+        if (ngx_queue_next(&ctx->queue)) {
+            ngx_queue_remove(&ctx->queue);
+        }
+
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
The patch addresses a possible crash in case of non-working LDAP server.

At the moment, if request context gets into `server->waiting_requests` queue, it can be read in `ngx_http_auth_ldap_get_connection()` after context memory is freed, because it is still in the queue after request was timed out.