### PR TITLE
Fix for OPENSSL Version detection

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -31,6 +31,7 @@
 #include <ngx_http.h>
 #include <ngx_md5.h>
 #include <ldap.h>
+#include <openssl/opensslv.h>
 
 // used for manual warnings
 #define XSTR(x) STR(x)


### PR DESCRIPTION
This should fix the OPENSSL_VERSION errors detailed in #125 and #123 -- essentially, it was trying to compare the OPENSSL_VERSION_NUMBER variable, which isn't present without the opensslv.h header file being imported.
This does mean that openssl-dev / libssl-devel packages need to be present in order for the module to compile, but that's generally going to be the case when compiling NGinX anyway.

Tested on my machine with OpenSSL 1.0.2g - was originally getting the messages as seen in the issue numbers above, and couldn't use LDAPS; now, no error, and LDAPS support working as expected.