### PR TITLE
adding max_down_retries for #136 and #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ expected value: valid_user, user, group
 ## satisfy
 expected value: all, any
 
+## max_down_retries_count
+expected value: a number, default 0
+
+Retry count for attempting to reconnect to an LDAP server if it is considered
+"DOWN".  This may happen if a KEEP-ALIVE connection to an LDAP server times 
+out or is terminated by the server end after some amount of time.  
+
+This can usually help with the following error:
+
+```
+http_auth_ldap: ldap_result() failed (-1: Can't contact LDAP server)
+```
+
 ## connections
 expected value: a number greater than 0
 


### PR DESCRIPTION
Implementation of a `max_down_retries` count utilized in the main `ngx_http_auth_ldap_read_handler` loop in order to retry connecting to an LDAP server if the underlying file descriptor asynchronously being selected on is closed or becomes disconnected.

I've tested with `max_down_retries = 0` and am able to re-create the can't connect errors.  Setting it to a number greater than zero shows reconnecting in debug logs and the proxy caller no longer times out.