### PR TITLE
Issue 180: wrong ldap dn path to search the group

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2236,12 +2236,12 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
             r->pool,
             for_filter);
         ngx_sprintf(filter, "(&(%s)(%s=%s))", cn_gr, ctx->server->group_attribute.data, user_val);
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: user \"%s\"", (const char *) user_val);
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: group_atr \"%s\"", (const char *) ctx->server->group_attribute.data);
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: group \"%s\"", (const char *) cn_gr);
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: ctx_dn \"%s\"", (const char *) ctx->dn.data);
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: ctx_user_dn \"%s\"", (const char *) ctx->user_dn.data);
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: user \"%s\"", (const char *) user_val);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: group_atr \"%s\"", (const char *) ctx->server->group_attribute.data);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: group \"%s\"", (const char *) cn_gr);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: ctx_dn \"%s\"", (const char *) ctx->dn.data);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: ctx_user_dn \"%s\"", (const char *) ctx->user_dn.data);
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
         attrs[0] = LDAP_NO_ATTRS;
         attrs[1] = NULL;
         rc = ldap_search_ext(ctx->c->ld, tail_gr, LDAP_SCOPE_ONELEVEL, (const char *) filter, attrs, 0, NULL, NULL, NULL, 0, &ctx->c->msgid);

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2236,9 +2236,6 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
             r->pool,
             for_filter);
         ngx_sprintf(filter, "(&(%s)(%s=%s))", cn_gr, ctx->server->group_attribute.data, user_val);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: user \"%s\"", (const char *) user_val);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: group_atr \"%s\"", (const char *) ctx->server->group_attribute.data);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: group \"%s\"", (const char *) cn_gr);
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
         attrs[0] = LDAP_NO_ATTRS;
         attrs[1] = NULL;

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2214,9 +2214,9 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
     if (ctx->server->group_attribute_dn == 1) {
         user_val = ngx_pcalloc(
             r->pool,
-            ctx->user_dn.len + 1);
-        ngx_memcpy(user_val, ctx->user_dn.data, ctx->user_dn.len);
-        user_val[ctx->user_dn.len] = '\0';
+            ctx->dn.len + 1);
+        ngx_memcpy(user_val, ctx->dn.data, ctx->dn.len);
+        user_val[ctx->dn.len] = '\0';
     } else {
         user_val = ngx_pcalloc(
             r->pool,

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2239,6 +2239,8 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: user \"%s\"", (const char *) user_val);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: group_atr \"%s\"", (const char *) ctx->server->group_attribute.data);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: group \"%s\"", (const char *) cn_gr);
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: ctx_dn \"%s\"", (const char *) ctx->dn.data);
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: ctx_user_dn \"%s\"", (const char *) ctx->user_dn.data);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
         attrs[0] = LDAP_NO_ATTRS;
         attrs[1] = NULL;

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2200,6 +2200,7 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
     ngx_memcpy(gr, val.data, val.len);
     gr[val.len] = '\0';
     tail_gr = ngx_strchr(gr, ',');
+    
     if (tail_gr == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: Incorrect group DN: \"%s\"", gr);
         ctx->outcome = OUTCOME_ERROR;
@@ -2235,6 +2236,8 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
             r->pool,
             for_filter);
         ngx_sprintf(filter, "(&(%s)(%s=%s))", cn_gr, ctx->server->group_attribute.data, user_val);
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: user \"%s\"", (const char *) user_val);
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: group \"%s\"", (const char *) cn_gr);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
         attrs[0] = LDAP_NO_ATTRS;
         attrs[1] = NULL;

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2237,6 +2237,7 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
             for_filter);
         ngx_sprintf(filter, "(&(%s)(%s=%s))", cn_gr, ctx->server->group_attribute.data, user_val);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: user \"%s\"", (const char *) user_val);
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: group_atr \"%s\"", (const char *) ctx->server->group_attribute.data);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: group \"%s\"", (const char *) cn_gr);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
         attrs[0] = LDAP_NO_ATTRS;

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2236,7 +2236,7 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
             r->pool,
             for_filter);
         ngx_sprintf(filter, "(&(%s)(%s=%s))", cn_gr, ctx->server->group_attribute.data, user_val);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
         attrs[0] = LDAP_NO_ATTRS;
         attrs[1] = NULL;
         rc = ldap_search_ext(ctx->c->ld, tail_gr, LDAP_SCOPE_ONELEVEL, (const char *) filter, attrs, 0, NULL, NULL, NULL, 0, &ctx->c->msgid);

--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2239,8 +2239,6 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: user \"%s\"", (const char *) user_val);
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: group_atr \"%s\"", (const char *) ctx->server->group_attribute.data);
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: group \"%s\"", (const char *) cn_gr);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: ctx_dn \"%s\"", (const char *) ctx->dn.data);
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: ctx_user_dn \"%s\"", (const char *) ctx->user_dn.data);
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: Search group filter is \"%s\"", (const char *) filter);
         attrs[0] = LDAP_NO_ATTRS;
         attrs[1] = NULL;


### PR DESCRIPTION
To resolve the users group, the coded used the wrong variables. So, the code was filtering against the users dn, but it have to filter against the group dn. :-) So, I just change it and hope u fell ok with it.