### PR TITLE
max_down_retries is the setting?

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ expected value: valid_user, user, group
 ## satisfy
 expected value: all, any
 
-## max_down_retries_count
+## max_down_retries
 expected value: a number, default 0
 
 Retry count for attempting to reconnect to an LDAP server if it is considered


### PR DESCRIPTION
I've been reading the implementation from [this](https://github.com/kvspb/nginx-auth-ldap/pull/169/files).  It feels like the documentation incorrectly suggests we should be setting the counter.  I notice the counter is reset [here](https://github.com/kvspb/nginx-auth-ldap/blob/master/ngx_http_auth_ldap_module.c#L1682).  Isn't the setting we are intended to configure `max_down_retries` found [here](https://github.com/kvspb/nginx-auth-ldap/blob/master/ngx_http_auth_ldap_module.c#L418-L424)?