### PR TITLE
Allow compiling on GCC < 5 / CentOS 6 (see #138)

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -41,7 +41,9 @@
 #pragma clang diagnostic warning "-W#warnings"
 #else
 #ifdef __GNUC__
+#if GNUC > 4
 #pragma GCC diagnostic warning "-Wcpp"
+#endif
 #endif
 #endif
 // TODO: do the same stuff for MSVC and/or other compilers
@@ -433,7 +435,9 @@ ngx_http_auth_ldap_ldap_server(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
       #if OPENSSL_VERSION_NUMBER >= 0x10002000
       server->ssl_check_cert = 1;
       #else
+      #if GNUC > 4
       #warning "http_auth_ldap: Compiling with OpenSSL < 1.0.2, certificate verification will be unavailable. OPENSSL_VERSION_NUMBER == " XSTR(OPENSSL_VERSION_NUMBER)
+      #endif
       ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
         "http_auth_ldap: 'ssl_cert_check': cannot verify remote certificate's domain name because "
         "your version of OpenSSL is too old. "


### PR DESCRIPTION
As per #138 (and specifically https://github.com/kvspb/nginx-auth-ldap/issues/138#issuecomment-317625746) the issue is that:

* nginx compiles with `-Werror` (treating warnings as errors)
* CentOS 6 has OpenSSL 1.0.1e, thus the LDAP module has a warning on compile
* CentOS 6 has GCC 4.4.  The version of GCC treats the LDAP module's statement `#pragma GCC diagnostic warning "-Wcpp"` as an error itself and thus skips the statement, leading to the `#warning` still being an error.

This adds version-checking to the warning options and the warning
itself.  This means that no warning is issued at compile time on this
type of platform, but warnings are still emitted when starting Nginx
without certificate verification, so the issue is still visible in a notable way.

Other solutions to making this module compile on CentOS 6 / GCC 4.4 are welcomed, but this seems like the lightest touch.