### PR TITLE
Revert #199 to fix group membership lookups

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -2216,7 +2216,6 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
     ngx_memcpy(gr, val.data, val.len);
     gr[val.len] = '\0';
     tail_gr = ngx_strchr(gr, ',');
-    
     if (tail_gr == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "http_auth_ldap: Incorrect group DN: \"%s\"", gr);
         ctx->outcome = OUTCOME_ERROR;
@@ -2230,9 +2229,9 @@ ngx_http_auth_ldap_check_group(ngx_http_request_t *r, ngx_http_auth_ldap_ctx_t *
     if (ctx->server->group_attribute_dn == 1) {
         user_val = ngx_pcalloc(
             r->pool,
-            ctx->dn.len + 1);
-        ngx_memcpy(user_val, ctx->dn.data, ctx->dn.len);
-        user_val[ctx->dn.len] = '\0';
+            ctx->user_dn.len + 1);
+        ngx_memcpy(user_val, ctx->user_dn.data, ctx->user_dn.len);
+        user_val[ctx->user_dn.len] = '\0';
     } else {
         user_val = ngx_pcalloc(
             r->pool,


### PR DESCRIPTION
This reverts commit bf64cf217abbe79917f9d44a651c2ecbb82ec993, reversing changes made to f022103e31e71e70a4bb64cd4c7792fa3f238b4a.

The PR in #199 contained changes that weren't right - breaking the behaviour of LDAP setups when `group_attribute_is_dn on` is enabled (eg what this line of code https://github.com/kvspb/nginx-auth-ldap/commit/bf64cf217abbe79917f9d44a651c2ecbb82ec993#diff-c05c0daefb48996cbf510b81002b49bcR2230 is conditionally targeting).  The PR in effect changes the [subsequent LDAP query](https://github.com/kvspb/nginx-auth-ldap/blob/e67df3d5fedfa12d398ba347c2fabc63b7bac603/ngx_http_auth_ldap_module.c#L2238) (eg `user_val`) from correctly looking up the user's DN as a group attribute in LDAP  to querying for groups with a `group_attribute` equalling the _group's_ DN (eg `ctx->dn` is the group's dn at this point, see [here](https://github.com/kvspb/nginx-auth-ldap/blob/e67df3d5fedfa12d398ba347c2fabc63b7bac603/ngx_http_auth_ldap_module.c#L2156)).  This isn't right and won't work, hence the breaking change.

This PR reverts the previous change to make this work correctly again.

Fwiw, the originally-referenced issue #180 in PR #199 seems to be a completely different issue, relating to escaping and parentheses so I'm not sure what/how the original author was trying to fix.