### PR TITLE
Allow auth_ldap in NGX_HTTP_LIF_CONF context.

### DIFF
--- a/ngx_http_auth_ldap_module.c
+++ b/ngx_http_auth_ldap_module.c
@@ -271,7 +271,7 @@ static ngx_command_t ngx_http_auth_ldap_commands[] = {
     },
     {
         ngx_string("auth_ldap"),
-        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1,
+        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_HTTP_LMT_CONF | NGX_CONF_TAKE1 | NGX_HTTP_LIF_CONF,
         ngx_http_auth_ldap,
         NGX_HTTP_LOC_CONF_OFFSET,
         0,


### PR DESCRIPTION
Сonfiguration example

```
geo $authentication {
    default "on";
    127.0.0.1 "off";
    192.168.0.0/24 "off";
...
}

server {
...
location / {
    if ($authentication = "on"){
       auth_ldap "UCS Auth required!";
    }
    auth_ldap_servers ucs;
...
}
```